### PR TITLE
remove a trailing slash of Client.BaseURL

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,6 +58,9 @@ type Client struct {
 
 // NewClient returns Backlog HTTP Client
 func NewClient(baseURL, APIKey string) *Client {
+	if strings.HasSuffix(baseURL, "/") {
+		baseURL = baseURL[0 : len(baseURL)-1]
+	}
 	s := &Client{
 		BaseURL: baseURL,
 		APIKey:  APIKey,

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,31 @@
+package gobacklog
+
+import (
+	"testing"
+)
+
+func TestNewClientAdjustedBaseURL(t *testing.T) {
+	tab := []struct {
+		BaseURL     string
+		AdjustedURL string
+	}{
+		{
+			BaseURL:     "http://example.com/",
+			AdjustedURL: "http://example.com",
+		},
+		{
+			BaseURL:     "http://example.com",
+			AdjustedURL: "http://example.com",
+		},
+		{
+			BaseURL:     "",
+			AdjustedURL: "",
+		},
+	}
+	for _, v := range tab {
+		c := NewClient(v.BaseURL, "")
+		if c.BaseURL != v.AdjustedURL {
+			t.Errorf(`NewClient(%q, ""): BaseURL = %q; want %q`, v.BaseURL, c.BaseURL, v.AdjustedURL)
+		}
+	}
+}


### PR DESCRIPTION
fixed an error caused by double slashes in BaseURL of Client.